### PR TITLE
Changed API URL. The old one stopped working

### DIFF
--- a/src/tkj/Economics/ClientableTrait.php
+++ b/src/tkj/Economics/ClientableTrait.php
@@ -12,7 +12,7 @@ trait ClientableTrait
      * E-conomics API url
      * @var string
      */
-    protected $apiUrl = 'https://www.e-conomic.com/secure/api1/EconomicWebservice.asmx?WSDL';
+    protected $apiUrl = 'https://api.e-conomic.com/secure/api1/EconomicWebService.asmx?wsdl';
 
     /**
      * Array with debug options


### PR DESCRIPTION
Earlier this morning, the e-conomic service stopped working. The old URL for the WSDL now returns a 404 error.