### PR TITLE
Add custom SoapClient options

### DIFF
--- a/src/tkj/Economics/Client.php
+++ b/src/tkj/Economics/Client.php
@@ -26,15 +26,18 @@ class Client implements ClientInterface
 
     /**
      * Client constructor
-     * @param integer   $agreement
-     * @param integer   $userId
-     * @param string    $password
+     * @param integer $agreement
+     * @param integer $userId
+     * @param string $password
+     * @param array $options
      */
-    public function __construct($agreement, $userId, $password)
+    public function __construct($agreement, $userId, $password, array $options = [])
     {
         $this->agreement = $agreement;
         $this->userId    = $userId;
         $this->password  = $password;
+
+        $this->debug = array_merge($this->debug, $options);
 
         $this->client = new SoapClient($this->apiUrl, $this->debug);
 

--- a/src/tkj/Economics/TokenClient.php
+++ b/src/tkj/Economics/TokenClient.php
@@ -12,11 +12,13 @@ class TokenClient implements ClientInterface {
 
     protected $appIdentifier;
 
-    public function __construct($token, $appToken, $appIdentifier)
+    public function __construct($token, $appToken, $appIdentifier, array $options = [])
     {
         $this->token = $token;
         $this->appToken = $appToken;
         $this->appIdentifier = $appIdentifier;
+
+        $this->debug = array_merge($this->debug, $options);
 
         $this->setupAppIndentifierContex();
 


### PR DESCRIPTION
I encountered a few intermittent "Error fetching http headers", and to fix it I needed to set the SoapClient option keep_alive to false.
With this change, users can add extra options as needed.